### PR TITLE
Feat/saved screen + book info screen

### DIFF
--- a/app/src/main/java/com/jrod7938/textchangeapp/components/Components.kt
+++ b/app/src/main/java/com/jrod7938/textchangeapp/components/Components.kt
@@ -912,18 +912,19 @@ fun AccountInfo(user: MUser, navController: NavController) {
         verticalAlignment = Alignment.CenterVertically
     ) {
         Text(
+            modifier = Modifier.fillMaxWidth(0.7f),
             text = "Hello, ${user.firstName} ${user.lastName}.",
             style = MaterialTheme.typography.titleLarge,
             fontWeight = FontWeight.Bold,
         )
         IconButton(
+            modifier = Modifier.size(30.dp),
             onClick = {
                 FirebaseAuth.getInstance().signOut()
                 navController.navigate(AppScreens.LoginScreen.name)
             }
         ) {
             Icon(
-                modifier = Modifier.size(30.dp),
                 imageVector = Icons.Default.ExitToApp,
                 contentDescription = "Logout",
                 tint = MaterialTheme.colorScheme.error

--- a/app/src/main/java/com/jrod7938/textchangeapp/components/Components.kt
+++ b/app/src/main/java/com/jrod7938/textchangeapp/components/Components.kt
@@ -1053,14 +1053,14 @@ fun BookInfoView(
                 modifier = Modifier.fillMaxWidth(),
                 horizontalArrangement = Arrangement.SpaceEvenly
             ) {
-                Button(
-                    colors = ButtonDefaults
-                        .buttonColors(containerColor = MaterialTheme.colorScheme.primary),
-                    onClick = onContactClicked
-                ) {
-                    Text(text = "Contact Seller", fontSize = 16.sp)
-                }
                 if (user.email != book.email) {
+                    Button(
+                        colors = ButtonDefaults
+                            .buttonColors(containerColor = MaterialTheme.colorScheme.primary),
+                        onClick = onContactClicked
+                    ) {
+                        Text(text = "Contact Seller", fontSize = 16.sp)
+                    }
                     Button(onClick = {
                         if (user.savedBooks.contains(book.bookID)) {
                             viewModel.unsaveBook(book)

--- a/app/src/main/java/com/jrod7938/textchangeapp/components/Components.kt
+++ b/app/src/main/java/com/jrod7938/textchangeapp/components/Components.kt
@@ -504,9 +504,9 @@ fun BottomNavigationBar(
                 icon = {
                     Icon(
                         modifier = Modifier.size(40.dp),
-                        imageVector = if (currentRoute == item.route) item.selectedIcon else item.unselectedIcon,
+                        imageVector = if (currentRoute?.contains(item.route) == true) item.selectedIcon else item.unselectedIcon,
                         contentDescription = null,
-                        tint = if (currentRoute == item.route) MaterialTheme.colorScheme.primary else Color.DarkGray
+                        tint = if (currentRoute?.contains(item.route) == true) MaterialTheme.colorScheme.primary else Color.DarkGray
                     )
                 },
                 label = {

--- a/app/src/main/java/com/jrod7938/textchangeapp/components/Components.kt
+++ b/app/src/main/java/com/jrod7938/textchangeapp/components/Components.kt
@@ -66,6 +66,7 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ArrowDropDown
 import androidx.compose.material.icons.filled.Check
 import androidx.compose.material.icons.filled.Clear
+import androidx.compose.material.icons.filled.ExitToApp
 import androidx.compose.material.icons.filled.Favorite
 import androidx.compose.material.icons.filled.Lock
 import androidx.compose.material.icons.filled.Person
@@ -121,6 +122,7 @@ import androidx.navigation.NavController
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.currentBackStackEntryAsState
 import coil.compose.rememberAsyncImagePainter
+import com.google.firebase.auth.FirebaseAuth
 import com.jrod7938.textchangeapp.R
 import com.jrod7938.textchangeapp.model.MBook
 import com.jrod7938.textchangeapp.model.MUser
@@ -903,12 +905,31 @@ fun AccountListings(
  * @see MUser
  */
 @Composable
-fun AccountInfo(user: MUser) {
-    Text(
-        text = "Hello, ${user.firstName} ${user.lastName}.",
-        style = MaterialTheme.typography.titleLarge,
-        fontWeight = FontWeight.Bold,
-    )
+fun AccountInfo(user: MUser, navController: NavController) {
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.SpaceEvenly,
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Text(
+            text = "Hello, ${user.firstName} ${user.lastName}.",
+            style = MaterialTheme.typography.titleLarge,
+            fontWeight = FontWeight.Bold,
+        )
+        IconButton(
+            onClick = {
+                FirebaseAuth.getInstance().signOut()
+                navController.navigate(AppScreens.LoginScreen.name)
+            }
+        ) {
+            Icon(
+                modifier = Modifier.size(30.dp),
+                imageVector = Icons.Default.ExitToApp,
+                contentDescription = "Logout",
+                tint = MaterialTheme.colorScheme.error
+            )
+        }
+    }
     Card(
         modifier = Modifier
             .fillMaxWidth()

--- a/app/src/main/java/com/jrod7938/textchangeapp/model/MBook.kt
+++ b/app/src/main/java/com/jrod7938/textchangeapp/model/MBook.kt
@@ -111,8 +111,8 @@ data class MBook(
                 imageURL = document.getString("imageURL") ?: "",
                 description = document.getString("description") ?: "",
                 isbn = document.getString("isbn") ?: "",
-                sellerConfirm = document.getBoolean("sellerConfirm") ?: false,
-                buyerConfirm = document.getBoolean("buyerConfirm") ?: false
+                sellerConfirm = document.getBoolean("seller_confirm") ?: false,
+                buyerConfirm = document.getBoolean("buyer_confirm") ?: false
             )
         }
     }

--- a/app/src/main/java/com/jrod7938/textchangeapp/navigation/AppNavigation.kt
+++ b/app/src/main/java/com/jrod7938/textchangeapp/navigation/AppNavigation.kt
@@ -145,6 +145,14 @@ fun AppNavigation() {
                     }
                     BookInfoScreen(navController = navController)
                 }
+                composable(route = "${AppScreens.BookInfoScreen.name}/{bookId}") {
+                    DisposableEffect(Unit) {
+                        showAppBars.value = true
+                        onDispose { }
+                    }
+                    val bookId = it.arguments?.getString("bookId")
+                    BookInfoScreen(navController = navController, bookId = bookId)
+                }
                 composable(route = AppScreens.SellBookScreen.name) {
                     DisposableEffect(Unit) {
                         showAppBars.value = true

--- a/app/src/main/java/com/jrod7938/textchangeapp/screens/account/AccountScreen.kt
+++ b/app/src/main/java/com/jrod7938/textchangeapp/screens/account/AccountScreen.kt
@@ -123,7 +123,8 @@ fun AccountScreen(
             )
             AccountListings(
                 bookListings = bookListings!!,
-                currentlyEditingBook = currentlyEditingBook
+                currentlyEditingBook = currentlyEditingBook,
+                navController = navController
             )
         }
     }

--- a/app/src/main/java/com/jrod7938/textchangeapp/screens/account/AccountScreen.kt
+++ b/app/src/main/java/com/jrod7938/textchangeapp/screens/account/AccountScreen.kt
@@ -100,7 +100,7 @@ fun AccountScreen(
                     onDismiss = { currentlyEditingBook.value = null }
                 )
             }
-            AccountInfo(user!!)
+            AccountInfo(user!!, navController = navController)
             Text(
                 text = "Selling",
                 style = MaterialTheme.typography.titleLarge,

--- a/app/src/main/java/com/jrod7938/textchangeapp/screens/account/AccountScreenViewModel.kt
+++ b/app/src/main/java/com/jrod7938/textchangeapp/screens/account/AccountScreenViewModel.kt
@@ -137,7 +137,7 @@ class AccountScreenViewModel : ViewModel() {
      *
      * @see MUser
      */
-    private suspend fun getUserInfo(): MUser? = withContext(Dispatchers.IO) {
+    suspend fun getUserInfo(): MUser? = withContext(Dispatchers.IO) {
         val docRef = db.collection("users").document(userDocID ?: return@withContext null)
 
         try {

--- a/app/src/main/java/com/jrod7938/textchangeapp/screens/details/BookInfoScreen.kt
+++ b/app/src/main/java/com/jrod7938/textchangeapp/screens/details/BookInfoScreen.kt
@@ -31,10 +31,97 @@
 
 package com.jrod7938.textchangeapp.screens.details
 
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.AlertDialog
+import androidx.compose.material3.Button
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.livedata.observeAsState
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation.NavHostController
+import com.jrod7938.textchangeapp.components.BookInfoView
 
 @Composable
-fun BookInfoScreen(navController: NavHostController) {
+fun BookInfoScreen(
+    navController: NavHostController,
+    bookId: String? = "",
+    viewModel: BookInfoScreenViewModel = viewModel()
+) {
+    val user by viewModel.user.observeAsState(initial = null)
+    val book by viewModel.book.observeAsState(initial = null)
+    val loading by viewModel.loading.observeAsState(initial = false)
+    val message by viewModel.message.collectAsState(initial = null)
 
+    val (showContactInfo, setContactInfo) = remember { mutableStateOf(false) }
+
+    LaunchedEffect(key1 = true) {
+        bookId?.let {
+            viewModel.fetchBookDetails(it)
+            viewModel.getUser()
+        }
+    }
+
+    if (loading && book == null) {
+        CircularProgressIndicator()
+    } else {
+        Column(
+            modifier = Modifier.fillMaxSize(),
+            verticalArrangement = Arrangement.Top,
+            horizontalAlignment = Alignment.CenterHorizontally
+        ) {
+            Text(
+                text = "Book Info Screen",
+                style = MaterialTheme.typography.titleLarge,
+                fontWeight = FontWeight.Bold
+            )
+            if (book != null && user != null) {
+                BookInfoView(
+                    book = book!!,
+                    user = user!!,
+                    onContactClicked = { setContactInfo(true) })
+            } else {
+                Text(
+                    text = "Failed to fetch book details: $message",
+                    style = MaterialTheme.typography.titleLarge,
+                    fontWeight = FontWeight.Bold
+                )
+            }
+        }
+
+        if (showContactInfo) {
+            AlertDialog(
+                backgroundColor = MaterialTheme.colorScheme.background,
+                onDismissRequest = { setContactInfo(false) },
+                title = { Text(text = "Seller's Email") },
+                text = { Text(text = book?.email ?: "") },
+                buttons = {
+                    Button(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(16.dp),
+                        onClick = { setContactInfo(false) }
+                    ) {
+                        Text("Close")
+                    }
+                }
+            )
+        }
+    }
 }
+
+

--- a/app/src/main/java/com/jrod7938/textchangeapp/screens/details/BookInfoScreen.kt
+++ b/app/src/main/java/com/jrod7938/textchangeapp/screens/details/BookInfoScreen.kt
@@ -50,12 +50,23 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation.NavHostController
 import com.jrod7938.textchangeapp.components.BookInfoView
 
+/**
+ * Screen that displays the details of a book.
+ *
+ * @param navController the navigation controller
+ * @param bookId the id of the book to display
+ * @param viewModel the view model
+ *
+ * @see BookInfoScreenViewModel
+ * @see BookInfoView
+ */
 @Composable
 fun BookInfoScreen(
     navController: NavHostController,
@@ -103,13 +114,33 @@ fun BookInfoScreen(
             }
         }
 
-        if (showContactInfo) {
+        if (showContactInfo && book != null) {
+            val context = LocalContext.current
+
             AlertDialog(
                 backgroundColor = MaterialTheme.colorScheme.background,
                 onDismissRequest = { setContactInfo(false) },
                 title = { Text(text = "Seller's Email") },
                 text = { Text(text = book?.email ?: "") },
                 buttons = {
+
+                    Button(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(16.dp),
+                        onClick = {
+                            book!!.let { book ->
+                                val emailIntent = viewModel.prepareInterestEmailIntent(book)
+                                emailIntent?.let { intent ->
+                                    context.startActivity(emailIntent)
+
+                                }
+                            }
+                        }
+                    ) {
+                        Text(text = "Send Email")
+                    }
+
                     Button(
                         modifier = Modifier
                             .fillMaxWidth()

--- a/app/src/main/java/com/jrod7938/textchangeapp/screens/details/BookInfoScreen.kt
+++ b/app/src/main/java/com/jrod7938/textchangeapp/screens/details/BookInfoScreen.kt
@@ -52,6 +52,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation.NavHostController
@@ -120,14 +121,18 @@ fun BookInfoScreen(
             AlertDialog(
                 backgroundColor = MaterialTheme.colorScheme.background,
                 onDismissRequest = { setContactInfo(false) },
-                title = { Text(text = "Seller's Email") },
-                text = { Text(text = book?.email ?: "") },
+                title = {
+                    Text(
+                        modifier = Modifier.fillMaxWidth(),
+                        text = "Contact Seller",
+                        textAlign = TextAlign.Center
+                    )
+                },
                 buttons = {
-
                     Button(
                         modifier = Modifier
                             .fillMaxWidth()
-                            .padding(16.dp),
+                            .padding(top = 16.dp, start = 16.dp, end = 16.dp),
                         onClick = {
                             book!!.let { book ->
                                 val emailIntent = viewModel.prepareInterestEmailIntent(book)

--- a/app/src/main/java/com/jrod7938/textchangeapp/screens/details/BookInfoScreen.kt
+++ b/app/src/main/java/com/jrod7938/textchangeapp/screens/details/BookInfoScreen.kt
@@ -76,7 +76,7 @@ fun BookInfoScreen(
         }
     }
 
-    if (loading && book == null) {
+    if (loading) {
         CircularProgressIndicator()
     } else {
         Column(

--- a/app/src/main/java/com/jrod7938/textchangeapp/screens/details/BookInfoScreenViewModel.kt
+++ b/app/src/main/java/com/jrod7938/textchangeapp/screens/details/BookInfoScreenViewModel.kt
@@ -31,6 +31,7 @@
 
 package com.jrod7938.textchangeapp.screens.details
 
+import android.content.Intent
 import android.util.Log
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
@@ -44,6 +45,22 @@ import com.jrod7938.textchangeapp.screens.account.AccountScreenViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 
+/**
+ * ViewModel for the BookInfoScreen.
+ *
+ * @property email String? the user's email
+ * @property userName String? the user's username
+ * @property _userName String? the user's username
+ * @property loading MutableLiveData<Boolean> the loading state
+ * @property message MutableStateFlow<String?> the message state
+ * @property user MutableLiveData<MUser> the user state
+ * @property book MutableLiveData<MBook> the book state
+ * @property accountVM AccountScreenViewModel the account view model
+ *
+ * @see ViewModel
+ * @see BookInfoScreen
+ * @see MBook
+ */
 class BookInfoScreenViewModel : ViewModel() {
 
     val email = FirebaseAuth.getInstance().currentUser?.email
@@ -65,6 +82,32 @@ class BookInfoScreenViewModel : ViewModel() {
     val book: LiveData<MBook> = _book
 
     private val accountVM = AccountScreenViewModel()
+
+    /**
+     * Prepares to send an Email
+     *
+     * @param mBook MBook to be contacted about
+     *
+     * @return Intent
+     *
+     * @see Int
+     */
+    fun prepareInterestEmailIntent(mBook: MBook): Intent {
+        val emailIntent = Intent(Intent.ACTION_SEND).apply {
+            type = "text/plain"
+            putExtra(
+                Intent.EXTRA_TEXT, "Hello, I am interested in purchasing your book " +
+                        "titled '${mBook.title}' for $${mBook.price}. You can contact me at $email." +
+                        "\n\nReminder from TxTchange: Please check the confirmation boxes in the book " +
+                        "details page once the sale has been completed."
+            )
+            putExtra(Intent.EXTRA_SUBJECT, "TxTchange: Interest in Book ${mBook.title}")
+            putExtra(Intent.EXTRA_BCC, arrayOf("TxTchangeS@gmail.com"))
+            putExtra(Intent.EXTRA_EMAIL, arrayOf(mBook.email))
+        }
+
+        return emailIntent
+    }
 
     /**
      * Fetches the user details from the database

--- a/app/src/main/java/com/jrod7938/textchangeapp/screens/details/BookInfoScreenViewModel.kt
+++ b/app/src/main/java/com/jrod7938/textchangeapp/screens/details/BookInfoScreenViewModel.kt
@@ -133,7 +133,7 @@ class BookInfoScreenViewModel : ViewModel() {
             }
 
         val categoryReference = db.collection(mBook.mCategory).document(mBook.bookID)
-        categoryReference.update("buyer_confirm", true)
+        categoryReference.update("buyer_confirm", !mBook.buyerConfirm)
             .addOnSuccessListener {
                 Log.d(
                     "buyerVerifiedBook",
@@ -173,7 +173,7 @@ class BookInfoScreenViewModel : ViewModel() {
             }
 
         val categoryReference = db.collection(mBook.mCategory).document(mBook.bookID)
-        categoryReference.update("seller_confirm", true)
+        categoryReference.update("seller_confirm", !mBook.sellerConfirm)
             .addOnSuccessListener {
                 Log.d(
                     "sellerVerifiedBook",

--- a/app/src/main/java/com/jrod7938/textchangeapp/screens/details/BookInfoScreenViewModel.kt
+++ b/app/src/main/java/com/jrod7938/textchangeapp/screens/details/BookInfoScreenViewModel.kt
@@ -38,271 +38,254 @@ import androidx.lifecycle.ViewModel
 import com.google.firebase.auth.FirebaseAuth
 import com.google.firebase.firestore.FieldValue
 import com.google.firebase.firestore.FirebaseFirestore
-import com.google.firebase.firestore.Query
 import com.jrod7938.textchangeapp.model.MBook
 import com.jrod7938.textchangeapp.model.MUser
+import com.jrod7938.textchangeapp.screens.account.AccountScreenViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
-import com.google.android.gms.tasks.Task
 
 class BookInfoScreenViewModel : ViewModel() {
+
+    val email = FirebaseAuth.getInstance().currentUser?.email
+
+    private val _userName: String? =
+        FirebaseAuth.getInstance().currentUser?.email?.split("@")?.get(0)
+    val userName = _userName
+
     private val _loading = MutableLiveData(false)
     val loading: LiveData<Boolean> = _loading
 
-    private val _errorMessage = MutableStateFlow<String?>(null)
-    val errorMessage: StateFlow<String?> = _errorMessage
+    private val _message = MutableStateFlow<String?>(null)
+    val message: StateFlow<String?> = _message
 
-    private val userName: String? =
-        FirebaseAuth.getInstance().currentUser?.email?.split("@")?.get(0)
+    private val _user = MutableLiveData<MUser>(null)
+    val user: LiveData<MUser> = _user
 
-    /**
-     * Queries Firestore (the Firebase database) using the input userID
-     * to delete the input bookID from the user's book_listings field.
-     *
-     * @param bookID A String corresponding to a book in the database's books collection.
-     * Assumes that each book_id field is unique for each document in the collection.
-     * @param user A String corresponding to a user in the database's users collection.
-     *
-     * @return Unit
-     *
-     * @see deleteListing
-     * @see deleteBook
-     */
-    private fun updateUserBookListings(bookID: String, user: String = userName!!) {
-        // Performs an update to the user's document by deleting the bookID from book_listings field
-        val db = FirebaseFirestore.getInstance()
-        val userDocRef = db.collection("users").document(user)
-        userDocRef.update("book_listings", FieldValue.arrayRemove(bookID))
-            .addOnSuccessListener {
-                Log.d(
-                    "updateUserBookListings",
-                    "Successful deletion from the current user's book_listings field." +
-                            "\nuser_id: $user \nDeleted book_id: $bookID"
-                )
-            }
-            .addOnFailureListener { exception ->
-                Log.e(
-                    "updateUserBookListings",
-                    "Error in updating the book_listings field in the user document: $exception" +
-                            "\nuser_id: $user " +
-                            "\nbook_id to delete: $bookID"
-                )
-            }
-    }
+    private val _book = MutableLiveData<MBook>(null)
+    val book: LiveData<MBook> = _book
+
+    private val accountVM = AccountScreenViewModel()
 
     /**
-     * Queries Firestore (the Firebase database) using the input bookID & userID
-     * to delete the corresponding book from the books collection.
-     * After a successful deletion, calls the updateUserBookListings
-     * with the same bookID & userID to delete from the corresponding user.
+     * Fetches the user details from the database
      *
-     * @param book A MBook corresponding to a book in the database's books collection.
-     * Assumes that each book_id field is unique for each document in the collection.
-     * @param userID A String corresponding to a user in the database's users collection.
-     * Assumes that each user_id field is unique for each document in the collection.
-     *
-     * @return Unit
-     *
-     * @see deleteListing
-     * @see updateUserBookListings
-     */
-    private fun deleteBook(book: MBook, userID: String) {
-        // Builds a query to search for the book in the books collection
-        val booksRef = FirebaseFirestore.getInstance().collection("books")
-        val bookQuery: Query =
-            booksRef.whereEqualTo("user_id", userID)
-                .whereEqualTo("book_id", book.bookID)
-
-        // Executes the book query to delete the book from the database
-        // then if successful, subsequently executes updateUserBookListings function
-        // (no parallel queries to prevent further errors in updateUserBookListings if this function fails)
-        bookQuery.get()
-            .addOnSuccessListener { documents ->
-                if (!documents.isEmpty) {
-                    val bookDocRef = documents.documents[0].reference
-                    bookDocRef.delete()
-                        .addOnSuccessListener {
-                            Log.d(
-                                "deleteBook",
-                                "Successful deletion of book document from database. " +
-                                        "\nDeleted book's book_id: ${book.bookID} \nDeleted book's user_id: $userID "
-                            )
-                            updateUserBookListings(book.bookID)
-                            updateCategoryListings(book)
-                        }
-                        .addOnFailureListener { exception ->
-                            Log.e(
-                                "deleteBook", "Error in deleting book document: $exception " +
-                                        "\nbook_id: ${book.bookID} \nuser_id: $userID "
-                            )
-                        }
-                } else {
-                    Log.e("deleteBook", "Error - documents: QuerySnapshot! is empty: $documents")
-                }
-            }
-            .addOnFailureListener { exception ->
-                Log.e(
-                    "deleteBook", "Error in searching for the book document: $exception" +
-                            "\nuser_id: $userID \nbook_id: ${book.bookID}"
-                )
-            }
-    }
-
-    /**
-     * Queries Firestore (the Firebase database) using the input bookID & userID
-     * to delete the corresponding book from the books collection.
-     *
-     * @param book A MBook corresponding to a book in the database's books collection.
-     *
-     * @return Unit
-     *
-     * @see deleteListing
-     * @see updateUserBookListings
-     */
-    private fun updateCategoryListings(book: MBook) {
-        val categoryRef = FirebaseFirestore.getInstance().collection(book.mCategory)
-        val categoryQuery: Query = categoryRef
-            .whereEqualTo("user_id", book.userId)
-            .whereEqualTo("book_id", book.bookID)
-
-        categoryQuery.get()
-            .addOnSuccessListener { documents ->
-                if (!documents.isEmpty) {
-                    val bookRef = documents.documents[0].reference
-                    bookRef.delete()
-                        .addOnSuccessListener {
-                            Log.d(
-                                "UpdateCategoryListing",
-                                "Success: ${book.bookID} has been deleted."
-                            )
-                        }.addOnFailureListener {
-                            Log.d(
-                                "UpdateCategoryListing",
-                                "Failed: ${book.bookID} has not deleted."
-                            )
-                        }
-                } else {
-                    Log.d("UpdateCategoryListing", "Failed: $documents is empty.")
-                }
-            }.addOnFailureListener {
-                Log.d("UpdateCategoryListing", "Failed: ${it.message}")
-            }
-    }
-
-    /**
-     * Deletes a book listing from the current user's bookListings List
-     * by using their user ID and using the book ID inputted to delete the book
-     * from the books collections then the user's book_listings field in the database.
-     *
-     * @param bookID A String corresponding to a book in the database's books collection.
-     * Assumes that each book_id field is unique for each document in the collection.
-     *
-     * @return Unit
-     *
-     * @see MBook for bookID
-     * @see deleteBook for book collections delete query
-     * @see updateUserBookListings for user's book_listings update
-     */
-    fun deleteListing(book: MBook) {
-        // Performs a check on the current user's id then, if valid, executes deleteBook
-        val userID: String = FirebaseAuth.getInstance().currentUser?.uid ?: ""
-        if (userID.isEmpty()) {
-            Log.e("deleteListing", "Error - current user's userID is null")
-            return // Stops function here
-        } else {
-            deleteBook(book, userID)
-        }
-    }
-
-    /**
-     * adds a book to current user's saved_favorites by using their user ID and the
-     * book_id associated with a book given by the addToFavorites function
-     *
-     * @param book an MBook object from the function addToFavorites
-     * @param userID a string corresponding to the current user in the database's users collection.
+     * @param userID String the user id
      *
      * @return Unit
      *
      * @see MUser
-     * @see addToFavorites
-     *
+     * @see FirebaseFirestore
+     * @see AccountScreenViewModel
      */
+    suspend fun getUser(userID: String = userName!!) {
+        _loading.postValue(true)
+        _user.value = accountVM.getUserInfo()
+        _loading.postValue(false)
+    }
 
-    private fun addFavorite(book: MBook, userID: String) {
+    /**
+     * Fetches the book details from the database
+     *
+     * @param bookId String the book id
+     *
+     * @return Unit
+     *
+     * @see MBook
+     * @see FirebaseFirestore
+     */
+    fun fetchBookDetails(bookId: String) {
+        _loading.postValue(true)
         val db = FirebaseFirestore.getInstance()
-        val userDocRef = db.collection("users").document(userID)
-        userDocRef
+        db.collection("books")
+            .document(bookId)
             .get()
             .addOnSuccessListener { document ->
-                val favorites = document.get("saved_books") as List<String>
-                if(favorites.size < 50) {
-                    userDocRef.update("saved_listings", FieldValue.arrayUnion(book.bookID))
-                        .addOnSuccessListener {
-                            Log.d(
-                                "addFavorite",
-                                "Successful addition to the current user's saved_books field." +
-                                        "\nuser_id: $userID \nadded book_id: ${book.bookID}"
-                            )
-                        }
-                        .addOnFailureListener { exception ->
-                            Log.e(
-                                "addFavorite",
-                                "Error in updating the current user's saved_books field in the user document: $exception" +
-                                        "\nuser_id: $userID " +
-                                        "\nbook_id to add ${book.bookID}"
-                            )
-                        }
-                } else {Log.d("favorite limit check", "too many books in favorites please remove some")}
-            }.addOnFailureListener {exception ->
-                Log.e(
-                    "favorite limit check",
-                    "Failure to return value to check user $userID favorite limite: $exception"
-
-                )
+                val book = MBook.fromDocument(document)
+                _book.postValue(book)
+                _loading.postValue(false)
+                Log.d("fetchBookDetails", "Successfully fetched book details")
+            }.addOnFailureListener { exception ->
+                _message.value = "Failed to fetch book details: ${exception.message}"
+                _loading.postValue(false)
+                Log.e("fetchBookDetails", "Failed to fetch book details: ${exception.message}")
             }
+    }
+
+    /**
+     * Updates the book in the database with the provided details.
+     *
+     * @param mBook MBook the edited book details.
+     *
+     * @return Unit
+     *
+     * @see MBook
+     */
+    fun buyerVerifiedBook(mBook: MBook) {
+        val db = FirebaseFirestore.getInstance()
+
+        val bookReference = db.collection("books").document(mBook.bookID)
+        bookReference.update("buyer_confirm", !mBook.buyerConfirm)
+            .addOnSuccessListener {
+                Log.d("buyerVerifiedBook", "Successfully updated buyerConfirm in books collection.")
+            }.addOnFailureListener { e ->
+                Log.e("buyerVerifiedBook", "Error updating buyerConfirm in books collection: $e")
+                _message.value = e.message
+            }
+
+        val categoryReference = db.collection(mBook.mCategory).document(mBook.bookID)
+        categoryReference.update("buyer_confirm", true)
+            .addOnSuccessListener {
+                Log.d(
+                    "buyerVerifiedBook",
+                    "Successfully updated buyerConfirm in books mCategory collection."
+                )
+            }.addOnFailureListener { e ->
+                Log.e(
+                    "buyerVerifiedBook",
+                    "Error updating buyerConfirm in books mCategory collection: $e"
+                )
+                _message.value = e.message
+            }
+    }
+
+    /**
+     * Updates the book in the database with the provided details.
+     *
+     * @param mBook MBook the edited book details.
+     *
+     * @return Unit
+     *
+     * @see MBook
+     */
+    fun sellerVerifiedBook(mBook: MBook) {
+        val db = FirebaseFirestore.getInstance()
+
+        val bookReference = db.collection("books").document(mBook.bookID)
+        bookReference.update("seller_confirm", !mBook.sellerConfirm)
+            .addOnSuccessListener {
+                Log.d(
+                    "sellerVerifiedBook",
+                    "Successfully updated sellerConfirm in books collection."
+                )
+            }.addOnFailureListener { e ->
+                Log.e("sellerVerifiedBook", "Error updating sellerConfirm in books collection: $e")
+                _message.value = e.message
+            }
+
+        val categoryReference = db.collection(mBook.mCategory).document(mBook.bookID)
+        categoryReference.update("seller_confirm", true)
+            .addOnSuccessListener {
+                Log.d(
+                    "sellerVerifiedBook",
+                    "Successfully updated sellerConfirm in books mCategory collection."
+                )
+            }.addOnFailureListener { e ->
+                Log.e(
+                    "sellerVerifiedBook",
+                    "Error updating sellerConfirm in books mCategory collection: $e"
+                )
+                _message.value = e.message
+            }
+    }
+
+    /**
+     * Removes the book from the database if both buyer and seller have confirmed.
+     *
+     * @param mBook MBook the book to be checked and possibly removed.
+     *
+     * @return Unit
+     *
+     * @see MBook
+     */
+    fun removeBookIfBothPartiesVerified(mBook: MBook) {
+        val db = FirebaseFirestore.getInstance()
+
+        if (mBook.buyerConfirm && mBook.sellerConfirm) {
+
+            val userID = mBook.email.split("@")[0]
+            val userReference = db.collection("users").document(userID)
+            userReference.update("book_listings", FieldValue.arrayRemove(mBook.bookID))
+                .addOnSuccessListener {
+                    Log.d("removeBook", "Successfully removed book from user's book_listings.")
+                }.addOnFailureListener { e ->
+                    Log.e("removeBook", "Error removing book from user's book_listings: $e")
+                }
+
+            val usersCollection = db.collection("users")
+            usersCollection.whereArrayContains("saved_books", mBook.bookID)
+                .get().addOnSuccessListener { querySnapshot ->
+                    for (document in querySnapshot) {
+                        document.reference.update(
+                            "saved_books",
+                            FieldValue.arrayRemove(mBook.bookID)
+                        )
+                    }
+                    Log.d("removeBook", "Successfully removed book from saved books of all users.")
+                }.addOnFailureListener { e ->
+                    Log.e("removeBook", "Error removing book from saved books: $e")
+                }
+
+            val categoryReference = db.collection(mBook.mCategory).document(mBook.bookID)
+            categoryReference.delete()
+                .addOnSuccessListener {
+                    Log.d("removeBook", "Successfully removed book from category collection.")
+                }.addOnFailureListener { e ->
+                    Log.e("removeBook", "Error removing book from category collection: $e")
+                }
+
+            val bookReference = db.collection("books").document(mBook.bookID)
+            bookReference.delete()
+                .addOnSuccessListener {
+                    Log.d("removeBook", "Successfully removed book from books collection.")
+                }.addOnFailureListener { e ->
+                    Log.e("removeBook", "Error removing book from books collection: $e")
+                }
+        }
     }
 
 
     /**
-     * Wrapper function that checks if a user is currently logged in and then generates an MBook object
-     * to send to the function addFavorite
+     * Saves the book in the user's collection by updating the "saved_books" field.
      *
-     * @param bookID a string depicting the book_id of a book in the database's collection books
+     * @param book MBook the book details.
      *
      * @return Unit
      *
-
      * @see MBook
-     * @see addFavorite
-     *
      */
-    fun addToFavorites(bookID: String) {
+    fun saveBook(book: MBook) {
         val db = FirebaseFirestore.getInstance()
-        val userID: String = FirebaseAuth.getInstance().currentUser?.uid ?: ""
-        if (userID.isEmpty()) {
-            Log.e("add to favorites", "Error - current user's userID is null")
-            return // Stops function here
-        } else {
-            db.collection("books")
-                .document(bookID)
-                .get()
-                .addOnSuccessListener { document ->
-                    val book = MBook.fromDocument(document)
-                    addFavorite(book, userID)
-                }
-                .addOnFailureListener { exception ->
-                    Log.e(
-                    "get book document",
-                    "failure to acquire book document: $exception" +
-                        "\n $bookID"
-                    )
-                }
 
+        val userReference = db.collection("users").document(userName!!)
+        userReference.update("saved_books", FieldValue.arrayUnion(book.bookID))
+            .addOnSuccessListener {
+                Log.d("saveBook", "Book successfully saved.")
+            }.addOnFailureListener { e ->
+                Log.e("saveBook", "Error saving book: $e")
+                _message.value = e.message
+            }
+    }
 
+    /**
+     * Removes the book from the user's saved books collection by updating the "saved_books" field.
+     *
+     * @param book MBook the book details.
+     *
+     * @return Unit
+     *
+     * @see MBook
+     */
+    fun unsaveBook(book: MBook) {
+        val db = FirebaseFirestore.getInstance()
 
-                }
-
-        }
-
+        val userReference = db.collection("users").document(userName!!)
+        userReference.update("saved_books", FieldValue.arrayRemove(book.bookID))
+            .addOnSuccessListener {
+                Log.d("unsaveBook", "Book successfully removed from saved books.")
+            }.addOnFailureListener { e ->
+                Log.e("unsaveBook", "Error removing book from saved books: $e")
+                _message.value = e.message
+            }
+    }
 
 }

--- a/app/src/main/java/com/jrod7938/textchangeapp/screens/details/BookInfoScreenViewModel.kt
+++ b/app/src/main/java/com/jrod7938/textchangeapp/screens/details/BookInfoScreenViewModel.kt
@@ -102,7 +102,7 @@ class BookInfoScreenViewModel : ViewModel() {
                         "details page once the sale has been completed."
             )
             putExtra(Intent.EXTRA_SUBJECT, "TxTchange: Interest in Book ${mBook.title}")
-            putExtra(Intent.EXTRA_BCC, arrayOf("TxTchangeS@gmail.com"))
+            putExtra(Intent.EXTRA_BCC, arrayOf("txtChangeTeam@gmail.com"))
             putExtra(Intent.EXTRA_EMAIL, arrayOf(mBook.email))
         }
 

--- a/app/src/main/java/com/jrod7938/textchangeapp/screens/details/BookInfoScreenViewModel.kt
+++ b/app/src/main/java/com/jrod7938/textchangeapp/screens/details/BookInfoScreenViewModel.kt
@@ -101,7 +101,7 @@ class BookInfoScreenViewModel : ViewModel() {
                         "\n\nReminder from TxTchange: Please check the confirmation boxes in the book " +
                         "details page once the sale has been completed."
             )
-            putExtra(Intent.EXTRA_SUBJECT, "TxTchange: Interest in Book ${mBook.title}")
+            putExtra(Intent.EXTRA_SUBJECT, "txtChange: Interest in Book ${mBook.title}")
             putExtra(Intent.EXTRA_BCC, arrayOf("txtChangeTeam@gmail.com"))
             putExtra(Intent.EXTRA_EMAIL, arrayOf(mBook.email))
         }

--- a/app/src/main/java/com/jrod7938/textchangeapp/screens/details/BookInfoScreenViewModel.kt
+++ b/app/src/main/java/com/jrod7938/textchangeapp/screens/details/BookInfoScreenViewModel.kt
@@ -98,7 +98,7 @@ class BookInfoScreenViewModel : ViewModel() {
             putExtra(
                 Intent.EXTRA_TEXT, "Hello, I am interested in purchasing your book " +
                         "titled '${mBook.title}' for $${mBook.price}. You can contact me at $email." +
-                        "\n\nReminder from TxTchange: Please check the confirmation boxes in the book " +
+                        "\n\nReminder from txtChange Team: Please check the confirmation boxes in the book " +
                         "details page once the sale has been completed."
             )
             putExtra(Intent.EXTRA_SUBJECT, "txtChange: Interest in Book ${mBook.title}")

--- a/app/src/main/java/com/jrod7938/textchangeapp/screens/saved/SavedBooksScreen.kt
+++ b/app/src/main/java/com/jrod7938/textchangeapp/screens/saved/SavedBooksScreen.kt
@@ -31,12 +31,108 @@
 
 package com.jrod7938.textchangeapp.screens.saved
 
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.material3.Button
+import androidx.compose.material3.Card
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.livedata.observeAsState
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.RectangleShape
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation.NavHostController
+import coil.compose.rememberAsyncImagePainter
+import com.jrod7938.textchangeapp.navigation.AppScreens
 
 @Composable
-fun SavedBooksScreen(navController: NavHostController) {
-    Text(text = "Saved Books Screen")
+fun SavedBooksScreen(
+    navController: NavHostController,
+    viewModel: SavedBooksScreenViewModel = viewModel()
+) {
+    val loading by viewModel.loading.observeAsState(initial = false)
+    val errorMessage by viewModel.errorMessage.collectAsState(initial = null)
+    val savedBooks by viewModel.savedBooks.observeAsState(initial = listOf())
 
+    Column(
+        modifier = Modifier.fillMaxSize(),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.Top
+    ) {
+        if (loading) {
+            CircularProgressIndicator(modifier = Modifier.align(Alignment.CenterHorizontally))
+        } else {
+            if (!errorMessage.isNullOrEmpty()) {
+                Text(
+                    text = errorMessage.toString(),
+                    style = MaterialTheme.typography.titleLarge,
+                    fontWeight = FontWeight.SemiBold,
+                    color = MaterialTheme.colorScheme.error
+                )
+            }
+            Text(
+                text = "Saved Books",
+                style = MaterialTheme.typography.titleLarge,
+                fontWeight = FontWeight.Bold,
+                color = MaterialTheme.colorScheme.onBackground
+            )
+            LazyColumn(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(16.dp)
+            ) {
+                items(savedBooks.size) {
+                    Card(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(8.dp)
+                    ) {
+                        Row(
+                            modifier = Modifier.padding(16.dp),
+                            verticalAlignment = Alignment.CenterVertically,
+                            horizontalArrangement = Arrangement.Start
+                        ) {
+                            Image(
+                                modifier = Modifier
+                                    .size(150.dp)
+                                    .padding(end = 16.dp),
+                                painter = rememberAsyncImagePainter(
+                                    model = savedBooks[it].imageURL
+                                ),
+                                contentDescription = "Image of ${savedBooks[it].title} book"
+                            )
+                            Column(
+                                modifier = Modifier.weight(1f),
+                                verticalArrangement = Arrangement.SpaceBetween
+                            ) {
+                                Text(text = "Title: ${savedBooks[it].title}")
+                                Text(text = "Author: ${savedBooks[it].author}")
+                                Text(text = "Price: $${savedBooks[it].price}")
+                                Button(
+                                    shape = RectangleShape,
+                                    onClick = { navController.navigate("${AppScreens.BookInfoScreen.name}/${savedBooks[it].bookID}") }
+                                ) {
+                                    Text(text = "View info")
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
 }

--- a/app/src/main/java/com/jrod7938/textchangeapp/screens/saved/SavedBooksScreenViewModel.kt
+++ b/app/src/main/java/com/jrod7938/textchangeapp/screens/saved/SavedBooksScreenViewModel.kt
@@ -31,61 +31,95 @@
 
 package com.jrod7938.textchangeapp.screens.saved
 
+import android.util.Log
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
 import com.google.firebase.auth.FirebaseAuth
+import com.google.firebase.firestore.FirebaseFirestore
 import com.jrod7938.textchangeapp.model.MBook
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
-import com.google.firebase.firestore.FirebaseFirestore
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.tasks.await
+import kotlinx.coroutines.withContext
 
-class SavedBooksScreenViewModel {
+/**
+ * ViewModel for the SavedBooksScreen
+ *
+ * @property _loading MutableLiveData<Boolean> that represents the loading state of the screen
+ * @property loading LiveData<Boolean> that represents the loading state of the screen
+ * @property _errorMessage MutableStateFlow<String?> that represents the error message of the screen
+ * @property errorMessage StateFlow<String?> that represents the error message of the screen
+ * @property userDoc String that represents the current user's email without @pride.hofstra.edu
+ * @property _savedBooks MutableLiveData<List<MBook>> that represents the current user's saved books
+ * @property savedBooks LiveData<List<MBook>> that represents the current user's saved books
+ *
+ * @see ViewModel
+ * @see MBook
+ */
+class SavedBooksScreenViewModel : ViewModel() {
     private val _loading = MutableLiveData(false)
     val loading: LiveData<Boolean> = _loading
 
     private val _errorMessage = MutableStateFlow<String?>(null)
     val errorMessage: StateFlow<String?> = _errorMessage
 
-    private val userID: String = FirebaseAuth.getInstance().currentUser?.uid ?: ""
+    private val userDoc: String =
+        FirebaseAuth.getInstance().currentUser?.email?.split("@")?.get(0) ?: ""
 
-    private val _sbooks = MutableLiveData<List<MBook>>()
-    val sbooks: LiveData<List<MBook>> = _sbooks
+    private val _savedBooks = MutableLiveData<List<MBook>>()
+    val savedBooks: LiveData<List<MBook>> = _savedBooks
+
+    private var fetchedBooks = false
+
+    init {
+
+        if (!fetchedBooks) {
+            viewModelScope.launch {
+                _savedBooks.value = loadSavedBooks()
+                fetchedBooks = true
+            }
+        }
+    }
 
     /**
      * Queries Firestore (Firebase database) to acquire the current user's list of saved books
      *
+     * @return Unit
+     *
      * @see MBook
      */
-    fun LoadSavedBooks() {
-        if (_loading.value == false) {
-            _loading.value = true
-            val db = FirebaseFirestore.getInstance()
-            try {
-                db.collection("users").document(userID).get()
-                    .addOnSuccessListener { document ->
-                        val sbooklist = document.get("saved_books") as List<String>
-                        val books = mutableListOf<MBook>()
-                        for (book in sbooklist) {
-                            db.collection("books")
-                                .document(book)
-                                .get()
-                                .addOnSuccessListener { document ->
-                                    val mBook = MBook.fromDocument(document)
-                                    books.add(mBook)
-                                }.addOnFailureListener {exception->
-                                    _errorMessage.value = exception.message
-                                }
-                        }
-                        _sbooks.value = books
-                    }.addOnFailureListener {exception->
-                        _errorMessage.value = exception.message
-                    }
+    private suspend fun loadSavedBooks(): List<MBook>? = withContext(Dispatchers.IO) {
+        _loading.postValue(true)
+        val db = FirebaseFirestore.getInstance()
+        val books = mutableListOf<MBook>()
 
+        try {
+            val document = db.collection("users").document(userDoc).get().await()
+            val savedBooks = document.get("saved_books") as? List<String> ?: listOf()
 
-            } catch(e: Exception){
-                _errorMessage.value = e.message
+            for (book in savedBooks) {
+                try {
+                    val doc = db.collection("books").document(book).get().await()
+                    val mBook = MBook.fromDocument(doc)
+                    books.add(mBook)
+                    Log.d("SavedBooksScreenViewModel", "loadSavedBooks: Added to list")
+                } catch (e: Exception) {
+                    Log.e("SavedBooksScreenViewModel", "Error fetching a saved book", e)
+                    _errorMessage.emit(e.message)
+                }
             }
-            _loading.value = false
+            Log.d("SavedBooksScreenViewModel", "loadSavedBooks: Complete")
+        } catch (e: Exception) {
+            Log.e("SavedBooksScreenViewModel", "Error fetching user's saved books", e)
+            _errorMessage.emit(e.message)
         }
+
+        _loading.postValue(false)
+        return@withContext books
     }
+
 }


### PR DESCRIPTION
This pull request closes #77 #78 #72 #80

Added Email Notification to Seller When Buyer is interested.
https://github.com/Jrod7938/TxTchangeApp/assets/46418742/cc85c789-bfc4-4c74-bc94-a3840abe52d1

Seller is able to access their books from the account screen. Clicking the book image will take them to the book info page where they can confirm sale.
Video Demo Of Seller Confirming Book Sale:
https://github.com/Jrod7938/TxTchangeApp/assets/46418742/e4a9b3c0-57be-440c-9460-750b7d8db8de


Buyer is able to access saved books by clicking the heart icon on the top right. Clicking the info button of a saved book within the saved book screen will take the user to the book info page to view the book info. The buyer is also able to confirm book sale in this screen.
Video Demo of Buyer Confirming Sale & Removing Book From Saved Books:
https://github.com/Jrod7938/TxTchangeApp/assets/46418742/d48b1695-2d72-429b-9510-8a7f96ef196a
https://github.com/Jrod7938/TxTchangeApp/assets/46418742/154e62de-f61c-40d6-b6c9-407d60ccb885


I have functions that also check if both the seller and buyer have confirmed to remove the book from the database.  I have checks to only allow the buyer to check the buyer box and for the seller to only check the seller box.

